### PR TITLE
Remove duplicate synth

### DIFF
--- a/examples/synthesis/yosys_template.j2
+++ b/examples/synthesis/yosys_template.j2
@@ -6,10 +6,7 @@ read_slang -f {{ cmdfile }} --top {{ top }}
 # Check design hierarchy and set top module
 hierarchy -check -top {{ top }}  # Replace 'top' with your top module name
 
-# Generic synthesis
-synth -top {{ top }}
-
-# Technology mapping
+# FPGA synthesis + technology mapping
 synth_ice40 -top {{ top }}
 
 # Get stats


### PR DESCRIPTION
In the yosys script template, "generic" synthesis and techmapping was being called before FPGA synthesis + techmapping. Only having the latter does instantiate hard block cells such as BRAM:
e.g.:  
```=== axil_ram ===

   Number of wires:                529
   Number of wire bits:           3362
   Number of public wires:         529
   Number of public wire bits:    3362
   Number of ports:                 21
   Number of port bits:            122
   Number of memories:               0
   Number of memory bits:            0
   Number of processes:              0
   Number of cells:                557
     SB_DFF                         50
     SB_DFFE                        40
     SB_DFFSR                        4
     SB_LUT4                       335
     SB_RAM40_4K                   128
```  
The next step is to enable the use of the yosys-syn plugin.

