### PR TITLE
uart_rfifo syntax fix

### DIFF
--- a/logikbench/blocks/uart/rtl/uart_rfifo.v
+++ b/logikbench/blocks/uart/rtl/uart_rfifo.v
@@ -253,13 +253,12 @@ module uart_rfifo #(
 
     // Additional logic for detection of error conditions (parity and framing) inside the FIFO
     // for the Line Status Register bit 7
-    reg error_det;
+    reg [FIFO_DEPTH-1:0] error_det;
     always @(*) begin
-        error_det = 1'b0;
         for (i = 0; i < FIFO_DEPTH; i = i + 1) begin
-            error_det |= |fifo[i];
+            error_det[i] = |fifo[i];
         end
     end
-    assign error_bit = error_det;
+    assign error_bit = |error_det;
 
 endmodule


### PR DESCRIPTION
Fixed small syntax issue in uart block

Syntax error from Vivado. Reminder that slang is used to pickle source files so the line number and filename in the log is not accurate.
```
| INFO     | blocks_uart_AreaO... | syn_fpga        | 0 | ERROR: [Synth 8-2716] syntax error near '|' [/home/rice/logikbench/examples/sc/build/uart/blocks_uart_AreaOptimized_high/syn_fpga/0/inputs/uart.v:1211]
| INFO     | blocks_uart_AreaO... | syn_fpga        | 0 | INFO: [Synth 8-10285] module 'uart_rfifo' is ignored due to previous errors [/home/rice/logikbench/examples/sc/build/uart/blocks_uart_AreaOptimized_high/syn_fpga/0/inputs/uart.v:1215]
| INFO     | blocks_uart_AreaO... | syn_fpga        | 0 | INFO: [Synth 8-10285] module 'uart_tfifo' is ignored due to previous errors [/home/rice/logikbench/examples/sc/build/uart/blocks_uart_AreaOptimized_high/syn_fpga/0/inputs/uart.v:1632]
| INFO     | blocks_uart_AreaO... | syn_fpga        | 0 | INFO: [Synth 8-10285] module 'uart_transmitter' is ignored due to previous errors [/home/rice/logikbench/examples/sc/build/uart/blocks_uart_AreaOptimized_high/syn_fpga/0/inputs/uart.v:2137]
| INFO     | blocks_uart_AreaO... | syn_fpga        | 0 | INFO: [Synth 8-10285] module 'uart' is ignored due to previous errors [/home/rice/logikbench/examples/sc/build/uart/blocks_uart_AreaOptimized_high/syn_fpga/0/inputs/uart.v:2995]
| INFO     | blocks_uart_AreaO... | syn_fpga        | 0 | INFO: [Synth 8-9084] Verilog file '/home/rice/logikbench/examples/sc/build/uart/blocks_uart_AreaOptimized_high/syn_fpga/0/inputs/uart.v' ignored due to errors
| INFO     | blocks_uart_AreaO... | syn_fpga        | 0 | ERROR: [Synth 8-12188] Failed to read verilog '/home/rice/logikbench/examples/sc/build/uart/blocks_uart_AreaOptimized_high/syn_fpga/0/inputs/uart.v'
```